### PR TITLE
fix: 当设置 Hash Key fields 为多个时，HSet 命令会报错，这里使用 HMSet 命令替换

### DIFF
--- a/backend/services/connection_service.go
+++ b/backend/services/connection_service.go
@@ -663,7 +663,7 @@ func (c *connectionService) SetKeyValue(connName string, db int, key, keyType st
 			return
 		} else {
 			if len(strs) > 1 {
-				err = rdb.HSet(ctx, key, strs).Err()
+				err = rdb.HMSet(ctx, key, strs).Err()
 				if err == nil && expiration > 0 {
 					rdb.Expire(ctx, key, expiration)
 				}
@@ -795,7 +795,7 @@ func (c *connectionService) AddHashField(connName string, db int, key string, ac
 		}
 	default:
 		// overwrite duplicated fields
-		_, err = rdb.HSet(ctx, key, fieldItems...).Result()
+		_, err = rdb.HMSet(ctx, key, fieldItems...).Result()
 		for i := 0; i < len(fieldItems); i += 2 {
 			updated[fieldItems[i].(string)] = fieldItems[i+1]
 		}


### PR DESCRIPTION
## 两处 Hash 设置的问题修复：

### 1.新增 key 为 Hash 类型时，多个 field 保存会失败：
###### 复现步骤：
![image](https://github.com/tiny-craft/tiny-rdm/assets/19618280/0cb46a72-7c5c-4dc4-bec8-1b778ad061a8)

###### 结果：
添加失败

### 2.新增已有 Hash 的 field 时，两个以上 field 保存会失败：
###### 复现步骤：
![image](https://github.com/tiny-craft/tiny-rdm/assets/19618280/64886108-3387-48d5-8f42-632fd0b99564)

###### 结果：
添加失败

## 修改方式：
connect_service.go 两处 `rdx.HSet()`  替换 `rdx.HMSet()`

变更后测试上面两处 以及其他功能 没问题.