### PR TITLE
feat: display human-readable ttl

### DIFF
--- a/frontend/src/components/content_value/ContentToolbar.vue
+++ b/frontend/src/components/content_value/ContentToolbar.vue
@@ -81,7 +81,9 @@ const onDeleteKey = () => {
                         <template v-if="ttl < 0">
                             {{ $t('interface.forever') }}
                         </template>
-                        <template v-else>{{ ttl }} {{ $t('common.second') }}</template>
+                        <template v-else>
+                            {{ Math.floor(ttl/3600) }}:{{ Math.floor((ttl%3600)/60) }}:{{ Math.floor(ttl%60) }}
+                        </template>
                     </n-button>
                 </template>
                 TTL


### PR DESCRIPTION
对于ttl很长的健，显示一个很大的int数字并不直观。比如`243607` 这个数字是多长，很难直观感受到。在这个PR中，将ttl显示为`xx天xx时xx分xx秒`，可以帮助理解。

另外这个时间会不会太长了，如果只有显示`xx天`，虽然丧失了精度，但是直观上更加简洁，你觉得呢 @tiny-craft 

<img width="785" alt="image" src="https://github.com/tiny-craft/tiny-rdm/assets/17907604/3b21ef87-e3a1-4c5e-9280-b17b9b82a0a1">