### PR TITLE
fix: 打开一个有ttl的ttl设置对话框后，再打开另一个没有ttl的对话框，显示的ttl为前一个ttl值

### DIFF
--- a/frontend/src/components/dialogs/SetTtlDialog.vue
+++ b/frontend/src/components/dialogs/SetTtlDialog.vue
@@ -29,11 +29,7 @@ watch(
                 ttlForm.db = tab.db
                 ttlForm.key = tab.key
                 ttlForm.keyCode = tab.keyCode
-                if (tab.ttl < 0) {
-                    // forever
-                } else {
-                    ttlForm.ttl = tab.ttl
-                }
+                ttlForm.ttl = tab.ttl
             }
         }
     },


### PR DESCRIPTION
### 复现流程
1. 选择一个有ttl的健，打开“设置ttl对话框”，然后关闭对话框
<img width="424" alt="image" src="https://github.com/tiny-craft/tiny-rdm/assets/17907604/36162193-8ea7-48c1-a28d-f15487334f11">

2. 再选择一个没有ttl的健，打开“设置ttl对话框”，对话框里显示的ttl是上一个建的
<img width="424" alt="image" src="https://github.com/tiny-craft/tiny-rdm/assets/17907604/48dba1e5-c3a3-4b02-b1b7-fb653a0bb3df">

### 期望
打开没有ttl的对话框后，应该显示-1