### PR TITLE
fix: add linux dependency

### DIFF
--- a/build/linux/tiny-rdm_0.0.0_amd64/DEBIAN/control
+++ b/build/linux/tiny-rdm_0.0.0_amd64/DEBIAN/control
@@ -3,6 +3,7 @@ Version: {{.Info.ProductVersion}}
 Section: base
 Priority: optional
 Architecture: amd64
+Depends: libwebkit2gtk-4.0-37
 Maintainer: {{.Author.Name}} <{{.Author.Email}}>
 Homepage: https://redis.tinycraft.cc/
 Description: {{.Info.Comments}}


### PR DESCRIPTION
部分 Linux 系统中没有预装 Webkit，添加此依赖安装 tinyrdm 时一起安装，避免安装成功后打不开