### PR TITLE
fix: reset `ReadTimeout`&`ReadTimeout` for sentinel mode through ssh

### DIFF
--- a/backend/services/connection_service.go
+++ b/backend/services/connection_service.go
@@ -226,6 +226,10 @@ func (c *connectionService) createRedisClient(config types.ConnectionConfig) (re
 		option.Addr = net.JoinHostPort(addr[0], addr[1])
 		option.Username = config.Sentinel.Username
 		option.Password = config.Sentinel.Password
+		if option.Dialer != nil {
+			option.ReadTimeout = -2
+			option.WriteTimeout = -2
+		}
 	}
 
 	if config.LastDB > 0 {


### PR DESCRIPTION
处理当使用sentinel模式时，通过ssh隧道连接报错ssh: tcpChan: deadline not supported。
原因：NewSentinelClient在init方法时，对ReadTimeout与WriteTimeout为-2的情况进行了值覆盖，导致后续报错
