### PR TITLE
feat: add libwebkit2gtk 4.1 support

### DIFF
--- a/.github/workflows/release-linux-webkit2-41.yaml
+++ b/.github/workflows/release-linux-webkit2-41.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   release:
     name: Release Linux App
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         platform:
@@ -64,7 +64,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libfuse-dev libfuse2
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libfuse-dev libfuse2
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -87,6 +87,7 @@ jobs:
         run: |
           CGO_ENABLED=1 wails build -platform ${{ matrix.platform }} \
           -ldflags "-X main.version=v${{ steps.normalise_version.outputs.version }} -X main.gaMeasurementID=${{ secrets.GA_MEASUREMENT_ID }} -X main.gaSecretKey=${{ secrets.LINUX_GA_SECRET }}" \
+          -tags webkit2_41 \
           -o tiny-rdm
 
       - name: Setup control template
@@ -98,7 +99,7 @@ jobs:
           content=$(echo "$content" | sed -e "s/{{.Author.Name}}/$(jq -r '.author.name' wails.json)/g")
           content=$(echo "$content" | sed -e "s/{{.Author.Email}}/$(jq -r '.author.email' wails.json)/g")
           content=$(echo "$content" | sed -e "s/{{.Info.Comments}}/$(jq -r '.info.comments' wails.json)/g")
-          content=$(echo "$content" | sed -e "s/{{.libwebkit2gtk.PackageName}}/libwebkit2gtk-4.0-37/g")
+          content=$(echo "$content" | sed -e "s/{{.libwebkit2gtk.PackageName}}/libwebkit2gtk-4.1-0/g")
           echo $content
           echo "$content" > build/linux/tiny-rdm_0.0.0_amd64/DEBIAN/control
 
@@ -120,57 +121,14 @@ jobs:
           sed -i 's/0.0.0/${{ steps.normalise_version.outputs.version }}/g' "tiny-rdm_${{ steps.normalise_version.outputs.version }}_amd64/DEBIAN/control"
           dpkg-deb --build -Zxz "tiny-rdm_${{ steps.normalise_version.outputs.version }}_amd64"
 
-      - name: Package up appimage file
-        run: |
-          curl https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/linuxdeploy-${{ steps.normalise_platform_arch.outputs.arch }}.AppImage \
-                -o linuxdeploy \
-                -L
-          chmod u+x linuxdeploy
-
-          ./linuxdeploy --appdir AppDir
-
-          pushd AppDir
-          # Copy WebKit files.
-          find /usr/lib* -name WebKitNetworkProcess -exec mkdir -p $(dirname '{}') \; -exec cp --parents '{}' "." \; || true
-          find /usr/lib* -name WebKitWebProcess -exec mkdir -p $(dirname '{}') \; -exec cp --parents '{}' "." \; || true
-          find /usr/lib* -name libwebkit2gtkinjectedbundle.so -exec mkdir -p $(dirname '{}') \; -exec cp --parents '{}' "." \; || true
-          popd
-
-
-          mkdir -p AppDir/usr/share/icons/hicolor/512x512/apps
-          build_dir="build/linux/tiny-rdm_${{ steps.normalise_version.outputs.version }}_amd64"
-
-          cp -r $build_dir/usr/share/icons/hicolor/512x512/apps/tiny-rdm.png AppDir/usr/share/icons/hicolor/512x512/apps/
-          cp $build_dir/usr/local/bin/tiny-rdm AppDir/usr/bin/
-
-
-          sed -i 's#/usr/local/bin/tiny-rdm#tiny-rdm#g' $build_dir/usr/share/applications/tiny-rdm.desktop
-
-          curl -o linuxdeploy-plugin-gtk.sh "https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
-
-          sed -i '/XDG_DATA_DIRS/a export WEBKIT_DISABLE_COMPOSITING_MODE=1' linuxdeploy-plugin-gtk.sh
-          chmod +x linuxdeploy-plugin-gtk.sh
-
-          curl -o AppDir/AppRun https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-${{ steps.normalise_platform_arch.outputs.arch }} -L
-
-          ./linuxdeploy --appdir AppDir \
-             --output=appimage \
-             --plugin=gtk \
-             -e $build_dir/usr/local/bin/tiny-rdm \
-             -d $build_dir/usr/share/applications/tiny-rdm.desktop
-
       - name: Rename deb
         working-directory: ./build/linux
-        run: mv "tiny-rdm_${{ steps.normalise_version.outputs.version }}_amd64.deb" "tiny-rdm_${{ steps.normalise_version.outputs.version }}_${{ steps.normalise_platform.outputs.tag }}.deb"
-
-      - name: Rename appimage
-        run: mv Tiny_RDM-${{ steps.normalise_platform_arch.outputs.arch }}.AppImage "tiny-rdm_${{ steps.normalise_version.outputs.version }}_${{ steps.normalise_platform.outputs.tag }}.AppImage"
+        run: mv "tiny-rdm_${{ steps.normalise_version.outputs.version }}_amd64.deb" "tiny-rdm_${{ steps.normalise_version.outputs.version }}_${{ steps.normalise_platform.outputs.tag }}_webkit2_41.deb"
 
       - name: Upload release asset
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ steps.normalise_version.outputs.version }}
           files: |
-            ./build/linux/tiny-rdm_${{ steps.normalise_version.outputs.version }}_${{ steps.normalise_platform.outputs.tag }}.deb
-            tiny-rdm_${{ steps.normalise_version.outputs.version }}_${{ steps.normalise_platform.outputs.tag }}.AppImage
+            ./build/linux/tiny-rdm_${{ steps.normalise_version.outputs.version }}_${{ steps.normalise_platform.outputs.tag }}_webkit2_41.deb
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/build/linux/tiny-rdm_0.0.0_amd64/DEBIAN/control
+++ b/build/linux/tiny-rdm_0.0.0_amd64/DEBIAN/control
@@ -3,7 +3,7 @@ Version: {{.Info.ProductVersion}}
 Section: base
 Priority: optional
 Architecture: amd64
-Depends: libwebkit2gtk-4.0-37
+Depends: {{.libwebkit2gtk.PackageName}}
 Maintainer: {{.Author.Name}} <{{.Author.Email}}>
 Homepage: https://redis.tinycraft.cc/
 Description: {{.Info.Comments}}


### PR DESCRIPTION
1、编译一个依赖 libwebkit2gtk 4.1 的版本，修复 Ubuntu 24.04 中没有 libwebkit2gtk 4.0 无法安装 #223 #429
2、deepin V23 中 libwebkit2gtk 4.0 有缩放问题，可以临时安装4.1版本的过渡一下 #416 