### PR TITLE
fix: console text selection misalignment

### DIFF
--- a/frontend/src/components/content_value/ContentCli.vue
+++ b/frontend/src/components/content_value/ContentCli.vue
@@ -569,7 +569,7 @@ const receiveTermOutput = (data) => {
 </style>
 
 <style lang="scss">
-.xterm-screen {
+.xterm {
     padding: 0 5px !important;
 }
 


### PR DESCRIPTION
In the latest implementation, you used the following CSS to control the horizontal padding of the terminal content.

```css
.xterm-screen {
    padding: 0 5px !important;
}
```

However, text selection highlighting is controlled by xterm using JavaScript, which is not affected by CSS. As a result, when double-clicking to select text, the highlight overlay becomes misaligned.

![image](https://github.com/user-attachments/assets/5a0c3bff-e414-4b9c-8dbb-6191bbbc1841)

The solution is to control the padding on `.xterm` instead of `.xterm-screen`.

![image](https://github.com/user-attachments/assets/95bc0558-0119-4a27-9fa8-cdada8b3f7f9)