### PR TITLE
chore: unify app data store dir on Windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,8 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/mac"
 	"github.com/wailsapp/wails/v2/pkg/options/windows"
 	runtime2 "github.com/wailsapp/wails/v2/pkg/runtime"
+	"os"
+	"path/filepath"
 	"runtime"
 	"tinyrdm/backend/consts"
 	"tinyrdm/backend/services"
@@ -120,6 +122,7 @@ func main() {
 			WebviewIsTransparent:              false,
 			WindowIsTranslucent:               false,
 			DisableFramelessWindowDecorations: false,
+			WebviewUserDataPath:               filepath.Join(os.Getenv("APPDATA"), "TinyRDM"),
 		},
 		Linux: &linux.Options{
 			ProgramName:         appName,


### PR DESCRIPTION
On Windows, the WebView-related data is stored under the path `%APPDATA%/tinyrdm.exe/EBWebView`, whereas other application data is stored under `%APPDATA%/TinyRDM`.

Would it be possible to unify these paths for better consistency?