### PR TITLE
chore(deps): update wails dependency to v2.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/redis/go-redis/v9 v9.14.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/vrischmann/userdir v0.0.0-20151206171402-20f291cebd68
-	github.com/wailsapp/wails/v2 v2.10.2
+	github.com/wailsapp/wails/v2 v2.11.0
 	golang.org/x/crypto v0.42.0
 	golang.org/x/net v0.44.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/wailsapp/go-webview2 v1.0.22 h1:YT61F5lj+GGaat5OB96Aa3b4QA+mybD0Ggq6N
 github.com/wailsapp/go-webview2 v1.0.22/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
 github.com/wailsapp/mimetype v1.4.1 h1:pQN9ycO7uo4vsUUuPeHEYoUkLVkaRntMnHJxVwYhwHs=
 github.com/wailsapp/mimetype v1.4.1/go.mod h1:9aV5k31bBOv5z6u+QP8TltzvNGJPmNJD4XlAL3U+j3o=
-github.com/wailsapp/wails/v2 v2.10.2 h1:29U+c5PI4K4hbx8yFbFvwpCuvqK9VgNv8WGobIlKlXk=
-github.com/wailsapp/wails/v2 v2.10.2/go.mod h1:XuN4IUOPpzBrHUkEd7sCU5ln4T/p1wQedfxP7fKik+4=
+github.com/wailsapp/wails/v2 v2.11.0 h1:seLacV8pqupq32IjS4Y7V8ucab0WZwtK6VvUVxSBtqQ=
+github.com/wailsapp/wails/v2 v2.11.0/go.mod h1:jrf0ZaM6+GBc1wRmXsM8cIvzlg0karYin3erahI4+0k=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 golang.org/x/crypto v0.42.0 h1:chiH31gIWm57EkTXpwnqf8qeuMUi0yekh6mT2AvFlqI=


### PR DESCRIPTION
Bump github.com/wailsapp/wails/v2 from v2.10.2 to v2.11.0 Update corresponding entries in go.mod and go.sum

Fix compilation issues caused by API incompatibility between versions   
PS E:\work\tiny-rdm> wails build                                             
Wails CLI v2.11.0


# Build Options

Platform(s)        | windows/amd64            
Compiler           | D:\software\go\bin\go.exe
Skip Bindings      | false                    
Build Mode         | production               
Devtools           | false                    
Frontend Directory | E:\work\tiny-rdm\frontend
Obfuscated         | false                    
Skip Frontend      | false                    
Compress           | false                    
Package            | true                     
Clean Bin Dir      | false                    
LDFlags            |                          
Tags               | []                       
Race Detector      | false                    

Warning: go.mod is using Wails '2.10.2' but the CLI is 'v2.11.0'. Consider updating your project's `go.mod` file.


# Building target: windows/amd64

  • Generating bindings: 2025/11/18 12:07:25 2025/11/18 12:07:25 preferences path: C:/Users/241200050/AppData/Roaming/TinyRDM/preferences.yaml
                                                                                                                                                                 
Done.
  • Installing frontend dependencies: Done.
  • Compiling frontend: Done.
  • Generating application assets: Done.
  • Compiling application: # github.com/wailsapp/wails/v2/internal/frontend/desktop/windows
E:\go\pkg\mod\github.com\wailsapp\wails\v2@v2.10.2\internal\frontend\desktop\windows\frontend.go:482:29: cannot use f.processMessage (value of type func(message string)) as func(message string, sender *edge.ICoreWebView2, args *edge.ICoreWebView2WebMessageReceivedEventArgs) value in assignment
  ERROR   exit status 1
  
  
<img width="590" height="86" alt="image" src="https://github.com/user-attachments/assets/ce90181d-b5ef-4bc0-8c8f-f3dc531c75d5" />


