### PR TITLE
feat(login): add gradient background

### DIFF
--- a/frontend/src/components/LoginPage.vue
+++ b/frontend/src/components/LoginPage.vue
@@ -20,6 +20,12 @@ const prefStore = usePreferencesStore()
 const i18n = useI18n()
 const emit = defineEmits(['login'])
 
+const bgGradient = computed(() =>
+    prefStore.isDark
+        ? 'linear-gradient(135deg, #2c1c1a 0%, #2a2219 20%, #1c2030 45%, #1a2535 65%, #251c28 85%, #2a1e1e 100%)'
+        : 'linear-gradient(135deg, #fce4e3 0%, #f5e6d8 20%, #e8eef8 45%, #dce8f8 65%, #f2e8f0 85%, #f8f0f0 100%)',
+)
+
 // --- Theme ---
 const themeMode = ref(localStorage.getItem(STORAGE_THEME_KEY) || 'auto')
 
@@ -227,7 +233,7 @@ const handleLogin = async () => {
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: v-bind('themeVars.bodyColor');
+    background: v-bind(bgGradient);
     padding: 16px;
     box-sizing: border-box;
 }


### PR DESCRIPTION
Replace solid background-color with 135deg linear gradient using brand colors (red/yellow/blue).
Supports dark mode auto-switch via prefStore.isDark.