### PR TITLE
fix: prefer valkey_version over redis_version for Valkey server (#573)

### DIFF
--- a/backend/services/browser_service.go
+++ b/backend/services/browser_service.go
@@ -229,7 +229,11 @@ func (b *browserService) OpenConnection(name string) (resp types.JSResp) {
 	if res, err := client.Info(ctx, "server").Result(); err == nil || errors.Is(err, redis.Nil) {
 		info := b.parseInfo(res)
 		serverInfo := maputil.Get(info, "Server", map[string]string{})
-		version = maputil.Get(serverInfo, "redis_version", "1.0.0")
+		// Prefer valkey_version if present, fallback to redis_version
+		version = maputil.Get(serverInfo, "valkey_version", "")
+		if version == "" {
+			version = maputil.Get(serverInfo, "redis_version", "1.0.0")
+		}
 	}
 
 	resp.Success = true

--- a/frontend/src/components/content_value/ContentServerStatus.vue
+++ b/frontend/src/components/content_value/ContentServerStatus.vue
@@ -250,13 +250,12 @@ onUnmounted(() => {
     stopAutoRefresh()
 })
 
-const isValkey = computed(() => {
-    return !!get(serverInfo.value, 'Server.valkey_version', '')
+const valkeyVersion = computed(() => {
+    return get(serverInfo.value, 'Server.valkey_version', '')
 })
 
 const redisVersion = computed(() => {
-    // Prefer valkey_version if present, fallback to redis_version
-    return get(serverInfo.value, 'Server.valkey_version', '') || get(serverInfo.value, 'Server.redis_version', '')
+    return get(serverInfo.value, 'Server.redis_version', '')
 })
 
 const redisMode = computed(() => {
@@ -600,8 +599,14 @@ const clientTableColumns = computed(() => {
             <template #header>
                 <n-space :wrap-item="false" align="center" inline size="small">
                     {{ props.server }}
-                    <n-tooltip v-if="redisVersion">
-                        {{ isValkey ? 'Valkey Version' : 'Redis Version' }}
+                    <n-tooltip v-if="valkeyVersion">
+                        Valkey Version
+                        <template #trigger>
+                            <n-tag size="small" type="primary">v{{ valkeyVersion }}</n-tag>
+                        </template>
+                    </n-tooltip>
+                    <n-tooltip v-else-if="redisVersion">
+                        Redis Version
                         <template #trigger>
                             <n-tag size="small" type="primary">v{{ redisVersion }}</n-tag>
                         </template>

--- a/frontend/src/components/content_value/ContentServerStatus.vue
+++ b/frontend/src/components/content_value/ContentServerStatus.vue
@@ -250,8 +250,13 @@ onUnmounted(() => {
     stopAutoRefresh()
 })
 
+const isValkey = computed(() => {
+    return !!get(serverInfo.value, 'Server.valkey_version', '')
+})
+
 const redisVersion = computed(() => {
-    return get(serverInfo.value, 'Server.redis_version', '')
+    // Prefer valkey_version if present, fallback to redis_version
+    return get(serverInfo.value, 'Server.valkey_version', '') || get(serverInfo.value, 'Server.redis_version', '')
 })
 
 const redisMode = computed(() => {
@@ -596,7 +601,7 @@ const clientTableColumns = computed(() => {
                 <n-space :wrap-item="false" align="center" inline size="small">
                     {{ props.server }}
                     <n-tooltip v-if="redisVersion">
-                        Redis Version
+                        {{ isValkey ? 'Valkey Version' : 'Redis Version' }}
                         <template #trigger>
                             <n-tag size="small" type="primary">v{{ redisVersion }}</n-tag>
                         </template>


### PR DESCRIPTION
- backend: check valkey_version first when opening connection, fallback to redis_version if not present
- frontend: display "Valkey Version" tooltip when connecting to a Valkey server, otherwise show "Redis Version"

https://github.com/tiny-craft/tiny-rdm/issues/573

<img width="2072" height="1210" alt="image" src="https://github.com/user-attachments/assets/05eaa152-9072-4284-8ccc-edd545723df2" />

<img width="2072" height="1210" alt="image" src="https://github.com/user-attachments/assets/f64308f0-1869-4b0a-939e-0cca44a21550" />
